### PR TITLE
feat(server): add TCP listener and finalize Axum app setup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,17 @@
-use db::DBClient;
-
 mod config;
 mod models;
 mod dtos;
 mod error;
 mod db;
 
+use axum::{http::{header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE}, HeaderValue, Method}, Router};
 use config::Config;
-// use b::DBClient;
+use db::{DBClient, UserExt};
+use dotenv::dotenv;
+use sqlx::postgres::PgPoolOptions;
+use tower_http::cors::CorsLayer;
 use tracing_subscriber::filter::LevelFilter;
+use tokio_cron_scheduler::{JobScheduler, Job};
 
 #[derive(Debug, Clone)]
 pub struct AppState {
@@ -22,6 +25,64 @@ async fn main() {
         .with_max_level(LevelFilter::DEBUG)
         .init();
 
-    // dotenv().ok();
-    // let config: = Config::init();
+    dotenv().ok();
+    let config = Config::init();
+
+    let pool = match PgPoolOptions::new()
+        .max_connections(10)
+        .connect(&config.database_url)
+        .await {
+            Ok(pool) => {
+                println!("Connection to database, berhasil!");
+                pool
+            }
+            Err(err) => {
+                println!("Connection to database: {:?}", err);
+                std::process::exit(1);
+            }
+        };
+        let cors = CorsLayer::new()
+            .allow_origin("http://localhost:3000". parse::<HeaderValue>().unwrap())
+            .allow_headers([AUTHORIZATION, ACCEPT, CONTENT_TYPE])
+            .allow_credentials(true)
+            .allow_methods([Method::GET, Method::PUT, Method::PUT]);
+
+        let db_client = DBClient::new(pool);
+        let app_state = AppState{
+            env: config.clone(),
+            db_client: db_client.clone(),
+        };
+
+        let _scheduler = JobScheduler::new().await.unwrap();
+
+        let job = Job::new_async("0 0 * * * *", {
+            move |_, _| {
+             let db_client = db_client.clone();
+             Box::pin(async move {
+                 println!("Running scheduled task to delete expired files...");
+                 if let Err(err) = db_client.delete_expired_files().await {
+                     eprintln!("Error deleting expired files: {:?}", err);
+                 } else {
+                     println!("Successfully deleted expired files.");
+                 }
+             })
+            } 
+         }).unwrap();
+
+         _scheduler.add(job).await.unwrap();
+
+         tokio::spawn(async move {
+            _scheduler.start().await.unwrap();
+         });
+
+         let app = Router::new().layer(cors.clone());
+         println!(
+            "{}",
+            format!("Server is running on http://localhost:{}", config.port)
+         );
+
+         let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", &config.port)).await.unwrap();
+         axum::serve(listener, app).await.unwrap();
+
+         
 }


### PR DESCRIPTION
- Integrated `tokio::net::TcpListener` to bind the server to `0.0.0.0` for broader accessibility.
- Completed Axum app setup with CORS configuration for secure cross-origin requests.
- Added a server log message to indicate the running URL and port.
- Configured Axum to serve the app using the `axum::serve` method.
- Retained support for scheduled tasks using `tokio-cron-scheduler` for deleting expired files.